### PR TITLE
revert to python3 for pmdtools

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,11 +41,6 @@ jobs:
         channels: conda-forge,bioconda,default
         python-version: ${{ matrix.python-version }}
 
-    - name: Install python2
-      run: |
-        sudo apt-get update
-        sudo apt-get install python2
-
     - name: Install snakemake
       run: mamba install snakemake numpy
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,7 +47,7 @@ jobs:
     - name: cache-conda
       uses: actions/cache@v2
       env:
-        CACHE_NUMBER: 3
+        CACHE_NUMBER: 4
       with:
         path: .test/.snakemake/conda
         key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('workflow/envs/*.yaml') }}

--- a/workflow/envs/mapdamage.yaml
+++ b/workflow/envs/mapdamage.yaml
@@ -4,6 +4,6 @@ channels:
   - defaults
 dependencies:
   - mapdamage2
-  - pysam>=1.16
+  - htslib==1.9
   - parallel
   - samtools

--- a/workflow/envs/mapdamage.yaml
+++ b/workflow/envs/mapdamage.yaml
@@ -4,5 +4,6 @@ channels:
   - defaults
 dependencies:
   - mapdamage2
+  - pysam>=1.16
   - parallel
   - samtools

--- a/workflow/envs/mapdamage.yaml
+++ b/workflow/envs/mapdamage.yaml
@@ -4,6 +4,6 @@ channels:
   - defaults
 dependencies:
   - mapdamage2
-  - htslib==1.9
+  - htslib<1.15.1
   - parallel
   - samtools

--- a/workflow/rules/authentic.smk
+++ b/workflow/rules/authentic.smk
@@ -38,7 +38,7 @@ rule aggregate:
         aggregate_PMD,
         aggregate_plots,
         aggregate_post,
-        aggregate_scores
+        aggregate_scores,
     output:
         "results/AUTHENTICATION/.{sample}_done",
     log:
@@ -178,7 +178,7 @@ rule PMD_scores:
     envmodules:
         *config["envmodules"]["malt"],
     shell:
-        "samtools view -h {input.bam} | python2 $(which pmdtools) --number 100000 --printDS > {output.scores}"
+        "samtools view -h {input.bam} | pmdtools --number 100000 --printDS > {output.scores}"
 
 
 rule Authentication_Plots:
@@ -220,7 +220,7 @@ rule Deamination:
     envmodules:
         *config["envmodules"]["malt"],
     shell:
-        "samtools view {input.bam} | python2 $(which pmdtools) --platypus --number 100000 > {output.tmp}; "
+        "samtools view {input.bam} | pmdtools --platypus --number 100000 > {output.tmp}; "
         "cd results/AUTHENTICATION/{wildcards.sample}/{wildcards.taxid}/{wildcards.refid}; "
         "R CMD BATCH $(which plotPMD); "
 
@@ -229,13 +229,13 @@ rule Authentication_Score:
     input:
         rma6="results/MALT/{sample}.trimmed.rma6",
         maltextractlog="results/AUTHENTICATION/{sample}/{taxid}/{sample}.trimmed.rma6_MaltExtract_output/log.txt",
-        name_list="results/AUTHENTICATION/{sample}/{taxid}/{refid}/name.list"
+        name_list="results/AUTHENTICATION/{sample}/{taxid}/{refid}/name.list",
     output:
         scores="results/AUTHENTICATION/{sample}/{taxid}/{refid}/authentication_scores.txt",
     message:
         "Authentication_Score: COMPUTING AUTHENTICATION SCORES"
     params:
-        exe=WORKFLOW_DIR / "scripts/score.R"
+        exe=WORKFLOW_DIR / "scripts/score.R",
     log:
         "logs/AUTHENTICATION_SCORE/{sample}_{taxid}_{refid}.log",
     conda:
@@ -244,6 +244,3 @@ rule Authentication_Score:
         *config["envmodules"]["malt"],
     shell:
         "Rscript {params.exe} {input.rma6} $(dirname {input.maltextractlog}) {input.name_list} $(dirname {input.name_list})"
-
-
-


### PR DESCRIPTION
PMD_tools does not need python2 when installed from conda, nor on Kebnekaise. So I have reverted to the default here.

This still does not seem to fix issue #71 so we need to run more tests to see what's going on there