### PR TITLE
Simplify authentication output folders, filenames

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,11 +41,6 @@ jobs:
         channels: conda-forge,bioconda,default
         python-version: ${{ matrix.python-version }}
 
-    - name: Install python2
-      run: |
-        sudo apt-get update
-        sudo apt-get install python2
-
     - name: Install snakemake
       run: mamba install snakemake numpy
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,7 +47,7 @@ jobs:
     - name: cache-conda
       uses: actions/cache@v2
       env:
-        CACHE_NUMBER: 3
+        CACHE_NUMBER: 4
       with:
         path: .test/.snakemake/conda
         key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('workflow/envs/*.yaml') }}

--- a/workflow/envs/mapdamage.yaml
+++ b/workflow/envs/mapdamage.yaml
@@ -3,6 +3,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
+  - htslib<1.15.1
   - mapdamage2
   - parallel
   - samtools

--- a/workflow/rules/authentic.smk
+++ b/workflow/rules/authentic.smk
@@ -118,11 +118,8 @@ rule Breadth_Of_Coverage:
         maltextractlog="results/AUTHENTICATION/{sample}/{taxid}/MaltExtract_output/log.txt",
     output:
         name_list="results/AUTHENTICATION/{sample}/{taxid}/name_list.txt",
-        sam="results/AUTHENTICATION/{sample}/{taxid}/{taxid}.sam",
-        bam="results/AUTHENTICATION/{sample}/{taxid}/{taxid}.bam",
-        sorted_bam="results/AUTHENTICATION/{sample}/{taxid}/{taxid}.sorted.bam",
-        breadth_of_coverage="results/AUTHENTICATION/{sample}/{taxid}/{taxid}.breadth_of_coverage",
-        fasta="results/AUTHENTICATION/{sample}/{taxid}/{taxid}.fasta",
+        sorted_bam="results/AUTHENTICATION/{sample}/{taxid}/sorted.bam",
+        breadth_of_coverage="results/AUTHENTICATION/{sample}/{taxid}/breadth_of_coverage",
     params:
         malt_fasta=config["malt_nt_fasta"],
         ref_id=get_ref_id,
@@ -136,19 +133,19 @@ rule Breadth_Of_Coverage:
         *config["envmodules"]["malt"],
     shell:
         "echo {params.ref_id} > {output.name_list}; "
-        "zgrep {params.ref_id} {input.sam} | uniq > {output.sam}; "
-        "samtools view -bS {output.sam} > {output.bam}; "
-        "samtools sort {output.bam} > {output.sorted_bam}; "
+        "zgrep {params.ref_id} {input.sam} | uniq > results/AUTHENTICATION/{wildcards.sample}/{wildcards.taxid}/{params.ref_id}.sam; "
+        "samtools view -bS results/AUTHENTICATION/{wildcards.sample}/{wildcards.taxid}/{params.ref_id}.sam > results/AUTHENTICATION/{wildcards.sample}/{wildcards.taxid}/{params.ref_id}.bam; "
+        "samtools sort results/AUTHENTICATION/{wildcards.sample}/{wildcards.taxid}/{params.ref_id}.bam > {output.sorted_bam}; "
         "samtools index {output.sorted_bam}; "
         "samtools depth -a {output.sorted_bam} > {output.breadth_of_coverage}; "
-        "seqtk subseq {params.malt_fasta} {output.name_list} > {output.fasta}"
+        "seqtk subseq {params.malt_fasta} {output.name_list} > results/AUTHENTICATION/{wildcards.sample}/{wildcards.taxid}/{params.ref_id}.fasta"
 
 
 rule Read_Length_Distribution:
     input:
-        bam="results/AUTHENTICATION/{sample}/{taxid}/{taxid}.sorted.bam",
+        bam="results/AUTHENTICATION/{sample}/{taxid}/sorted.bam",
     output:
-        distribution="results/AUTHENTICATION/{sample}/{taxid}/{taxid}.read_length.txt",
+        distribution="results/AUTHENTICATION/{sample}/{taxid}/read_length.txt",
     message:
         "Read_Length_Distribution: COMPUTING READ LENGTH DISTRIBUTION"
     log:
@@ -163,9 +160,9 @@ rule Read_Length_Distribution:
 
 rule PMD_scores:
     input:
-        bam="results/AUTHENTICATION/{sample}/{taxid}/{taxid}.sorted.bam",
+        bam="results/AUTHENTICATION/{sample}/{taxid}/sorted.bam",
     output:
-        scores="results/AUTHENTICATION/{sample}/{taxid}/{taxid}.PMDscores.txt",
+        scores="results/AUTHENTICATION/{sample}/{taxid}/PMDscores.txt",
     message:
         "PMD_scores: COMPUTING PMD SCORES"
     log:
@@ -182,9 +179,9 @@ rule Authentication_Plots:
     input:
         dir="results/AUTHENTICATION/{sample}/{taxid}",
         node_list="results/AUTHENTICATION/{sample}/{taxid}/node_list.txt",
-        distribution="results/AUTHENTICATION/{sample}/{taxid}/{taxid}.read_length.txt",
-        scores="results/AUTHENTICATION/{sample}/{taxid}/{taxid}.PMDscores.txt",
-        breadth_of_coverage="results/AUTHENTICATION/{sample}/{taxid}/{taxid}.breadth_of_coverage",
+        distribution="results/AUTHENTICATION/{sample}/{taxid}/read_length.txt",
+        scores="results/AUTHENTICATION/{sample}/{taxid}/PMDscores.txt",
+        breadth_of_coverage="results/AUTHENTICATION/{sample}/{taxid}/breadth_of_coverage",
     output:
         plot="results/AUTHENTICATION/{sample}/{taxid}/authentic_Sample_{sample}.trimmed.rma6_TaxID_{taxid}.pdf",
     params:
@@ -203,7 +200,7 @@ rule Authentication_Plots:
 
 rule Deamination:
     input:
-        bam="results/AUTHENTICATION/{sample}/{taxid}/{taxid}.sorted.bam",
+        bam="results/AUTHENTICATION/{sample}/{taxid}/sorted.bam",
     output:
         tmp="results/AUTHENTICATION/{sample}/{taxid}/PMD_temp.txt",
         pmd="results/AUTHENTICATION/{sample}/{taxid}/PMD_plot.frag.pdf",

--- a/workflow/rules/authentic.smk
+++ b/workflow/rules/authentic.smk
@@ -38,7 +38,7 @@ rule aggregate:
         aggregate_PMD,
         aggregate_plots,
         aggregate_post,
-        aggregate_scores
+        aggregate_scores,
     output:
         "results/AUTHENTICATION/.{sample}_done",
     log:
@@ -178,7 +178,7 @@ rule PMD_scores:
     envmodules:
         *config["envmodules"]["malt"],
     shell:
-        "samtools view -h {input.bam} | python2 $(which pmdtools) --number 100000 --printDS > {output.scores}"
+        "samtools view -h {input.bam} | pmdtools --number 100000 --printDS > {output.scores}"
 
 
 rule Authentication_Plots:
@@ -220,7 +220,7 @@ rule Deamination:
     envmodules:
         *config["envmodules"]["malt"],
     shell:
-        "samtools view {input.bam} | python2 $(which pmdtools) --platypus --number 100000 > {output.tmp}; "
+        "samtools view {input.bam} | pmdtools --platypus --number 100000 > {output.tmp}; "
         "cd results/AUTHENTICATION/{wildcards.sample}/{wildcards.taxid}/{wildcards.refid}; "
         "R CMD BATCH $(which plotPMD); "
 
@@ -229,13 +229,13 @@ rule Authentication_Score:
     input:
         rma6="results/MALT/{sample}.trimmed.rma6",
         maltextractlog="results/AUTHENTICATION/{sample}/{taxid}/{sample}.trimmed.rma6_MaltExtract_output/log.txt",
-        name_list="results/AUTHENTICATION/{sample}/{taxid}/{refid}/name.list"
+        name_list="results/AUTHENTICATION/{sample}/{taxid}/{refid}/name.list",
     output:
         scores="results/AUTHENTICATION/{sample}/{taxid}/{refid}/authentication_scores.txt",
     message:
         "Authentication_Score: COMPUTING AUTHENTICATION SCORES"
     params:
-        exe=WORKFLOW_DIR / "scripts/score.R"
+        exe=WORKFLOW_DIR / "scripts/score.R",
     log:
         "logs/AUTHENTICATION_SCORE/{sample}_{taxid}_{refid}.log",
     conda:
@@ -244,6 +244,3 @@ rule Authentication_Score:
         *config["envmodules"]["malt"],
     shell:
         "Rscript {params.exe} {input.rma6} $(dirname {input.maltextractlog}) {input.name_list} $(dirname {input.name_list})"
-
-
-

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -171,7 +171,7 @@ def aggregate_maltextract(wildcards):
         os.path.join(os.path.dirname(checkpoint_output), "{taxid,[0-9]+}")
     ).taxid
     return expand(
-        "results/AUTHENTICATION/{sample}/{taxid}/{sample}.trimmed.rma6_MaltExtract_output/log.txt",
+        "results/AUTHENTICATION/{sample}/{taxid}/MaltExtract_output/log.txt",
         sample=wildcards.sample,
         taxid=taxid,
     )
@@ -180,7 +180,9 @@ def aggregate_maltextract(wildcards):
 def _aggregate_utils(fmt, wildcards):
     """Collect common output for all aggregate functions. Returns a tuple
     of lists sample, taxid, and refid"""
-    logger.debug(f"Running _aggregate_utils for format '{fmt}', wildcards '{dict(wildcards)}'")
+    logger.debug(
+        f"Running _aggregate_utils for format '{fmt}', wildcards '{dict(wildcards)}'"
+    )
     res = []
     checkpoint_output = checkpoints.Create_Sample_TaxID_Directories.get(
         sample=wildcards.sample
@@ -204,25 +206,29 @@ def _aggregate_utils(fmt, wildcards):
 
 
 def aggregate_PMD(wildcards):
-    fmt = "results/AUTHENTICATION/{sample}/{taxid}/{refid}/PMD_plot.frag.pdf"
+    fmt = "results/AUTHENTICATION/{sample}/{taxid}/PMD_plot.frag.pdf"
     return _aggregate_utils(fmt, wildcards)
+
 
 def aggregate_plots(wildcards):
-    fmt = "results/AUTHENTICATION/{sample}/{taxid}/{refid}/authentic_Sample_{sample}.trimmed.rma6_TaxID_{taxid}.pdf"
+    fmt = "results/AUTHENTICATION/{sample}/{taxid}/authentic_Sample_{sample}.trimmed.rma6_TaxID_{taxid}.pdf"
     return _aggregate_utils(fmt, wildcards)
+
 
 def aggregate_scores(wildcards):
-    fmt = "results/AUTHENTICATION/{sample}/{taxid}/{refid}/authentication_scores.txt"
+    fmt = "results/AUTHENTICATION/{sample}/{taxid}/authentication_scores.txt"
     return _aggregate_utils(fmt, wildcards)
 
+
 def aggregate_post(wildcards):
-    fmt = "results/AUTHENTICATION/{sample}/{taxid}/{sample}.trimmed.rma6_MaltExtract_output/analysis.RData"
+    fmt = "results/AUTHENTICATION/{sample}/{taxid}/MaltExtract_output/analysis.RData"
     return _aggregate_utils(fmt, wildcards)
+
 
 def get_ref_id(wildcards):
     """Return reference id for a given taxonomy id"""
     ref_id = wildcards.taxid
-    infile = f"results/AUTHENTICATION/{wildcards.sample}/{wildcards.taxid}/{wildcards.sample}.trimmed.rma6_MaltExtract_output/default/readDist/{wildcards.sample}.trimmed.rma6_additionalNodeEntries.txt"
+    infile = f"results/AUTHENTICATION/{wildcards.sample}/{wildcards.taxid}/MaltExtract_output/default/readDist/{wildcards.sample}.trimmed.rma6_additionalNodeEntries.txt"
     if not os.path.exists(infile):
         logger.debug(f"No such file {infile}; cannot extract refid")
         return None
@@ -240,4 +246,4 @@ def get_ref_id(wildcards):
 
 def format_maltextract_output_directory(wildcards):
     """Format MaltExtract output directory name"""
-    return f"results/AUTHENTICATION/{wildcards.sample}/{wildcards.taxid}/{wildcards.sample}.trimmed.rma6_MaltExtract_output/"
+    return f"results/AUTHENTICATION/{wildcards.sample}/{wildcards.taxid}/MaltExtract_output/"

--- a/workflow/scripts/authentic.R
+++ b/workflow/scripts/authentic.R
@@ -26,7 +26,7 @@ barplot(as.numeric(df[1,]),names=c(0:10),xlab="Number of mismatches",ylab="Numbe
 
 #BREADTH OF COVERAGE
 # FIXME: empty due to failed samtools sort
-df<-read.delim(paste0(out_dir,"/",RefID,".breadth_of_coverage"),header=FALSE,sep="\t")
+df<-read.delim(paste0(out_dir,"/breadth_of_coverage"),header=FALSE,sep="\t")
 N_tiles<-100
 step=(max(df$V2)-min(df$V2))/N_tiles
 tiles<-c(0:N_tiles)*step
@@ -54,11 +54,11 @@ lines(x=11:20,dam[1,11:20],col='blue',lwd=1.5)
 axis(1, at=seq(1,20,2), labels=c(seq(1,10,2),seq(-10,-1,2)))
 
 #READ LENGTH DISTRIBUTION
-df<-as.numeric(scan(paste0(out_dir,"/",RefID,".read_length.txt"),what="character"))
+df<-as.numeric(scan(paste0(out_dir,"/read_length.txt"),what="character"))
 hist(df,breaks=length(df),xlab="Read length",main="Read length distribution")
 
 #PMD SCORES DISTRIBUTION
-df<-read.delim(paste0(out_dir,"/",RefID,".PMDscores.txt"),header=FALSE,sep="\t")
+df<-read.delim(paste0(out_dir,"/PMDscores.txt"),header=FALSE,sep="\t")
 hist(df$V4,breaks=length(df$V4),main="Histogram of PMD scores",xlab="PMDscores")
 abline(v=3,col="red",lty=2)
 

--- a/workflow/scripts/authentic.R
+++ b/workflow/scripts/authentic.R
@@ -10,9 +10,9 @@ pdf(paste0(out_dir,"/","authentic_Sample_",RMA6,"_TaxID_",taxid,".pdf"),paper="a
 par(mfrow=c(3,3))
 
 #HELP INFORMATION
-organism<-readLines(paste0(dirname(out_dir),"/node_list.txt")) #scientific name of oranism, extracted automatically from NCBI NT by taxID
+organism<-readLines(paste0(out_dir,"/node_list.txt")) #scientific name of oranism, extracted automatically from NCBI NT by taxID
 RefID<-taxid
-MaltExtract_output_path<-paste0(dirname(out_dir),"/",RMA6,"_MaltExtract_output") #path to MaltExtract output directory
+MaltExtract_output_path<-paste0(out_dir,"/MaltExtract_output") #path to MaltExtract output directory
 
 #EDIT DISTANCE FOR ALL READS
 df<-read.delim(paste0(MaltExtract_output_path,"/default/editDistance/",RMA6,"_editDistance.txt"),header=TRUE,check.names=FALSE,row.names=1,sep="\t")


### PR DESCRIPTION
Here I have removed one level of directory (from taxid/refid to taxid/). In order to keep track of what reference is used, I renamed the bam/sam/fasta files with the refid instead. I have also simplified the maltextract output dirname.

Here is how the outputs looked before:
```
tree .test/results/AUTHENTICATION/bar/632/
.test/results/AUTHENTICATION/bar/632/
├── bar.trimmed.rma6_MaltExtract_output
...
├── node_list.txt
└── ref_64
    ├── 632.bam
    ├── 632.breadth_of_coverage
    ├── 632.fasta
    ├── 632.PMDscores.txt
    ├── 632.read_length.txt
    ├── 632.sam
    ├── 632.sorted.bam
    ├── 632.sorted.bam.bai
    ├── authentication_scores.txt
    ├── authentic_Sample_bar.trimmed.rma6_TaxID_632.pdf
    ├── name.list
    ├── plotPMD.Rout
    ├── PMD_plot.frag.pdf
    └── PMD_temp.txt

27 directories, 52 files

```
how they looks now:

```
 tree .test/results/AUTHENTICATION/bar/632/
.test/results/AUTHENTICATION/bar/632/
├── authentication_scores.txt
├── authentic_Sample_bar.trimmed.rma6_TaxID_632.pdf
├── breadth_of_coverage
├── MaltExtract_output
...
├── name_list.txt
├── node_list.txt
├── plotPMD.Rout
├── PMD_plot.frag.pdf
├── PMDscores.txt
├── PMD_temp.txt
├── read_length.txt
├── ref_64.bam
├── ref_64.fasta
├── ref_64.sam
├── sorted.bam
└── sorted.bam.bai

26 directories, 52 files
```