### PR TITLE
add brackets + true before the pmdtools pipe

### DIFF
--- a/workflow/rules/authentic.smk
+++ b/workflow/rules/authentic.smk
@@ -193,7 +193,7 @@ rule PMD_scores:
     envmodules:
         *config["envmodules"]["malt"],
     shell:
-        "samtools view -h {input.bam} | pmdtools --number 100000 --printDS > {output.scores}"
+        "(samtools view -h {input.bam} || true) | pmdtools --number 100000 --printDS > {output.scores}"
 
 
 rule Authentication_Plots:
@@ -234,7 +234,7 @@ rule Deamination:
     envmodules:
         *config["envmodules"]["malt"],
     shell:
-        "samtools view {input.bam} | pmdtools --platypus --number 100000 > {output.tmp}; "
+        "(samtools view {input.bam} || true) | pmdtools --platypus --number 100000 > {output.tmp}; "
         "cd results/AUTHENTICATION/{wildcards.sample}/{wildcards.taxid}; "
         "R CMD BATCH $(which plotPMD); "
 


### PR DESCRIPTION
Fixes issue #71.
We have limited the number for PMDtools (for another fix), however samtools was continuing to transmit into a closed pipe probably generating the non-zero exit status. This fixes the error I encountered for rule PMD_score and Deamination in my recent project at least. 