### PR TITLE
No rebuilding of bowtie2 database, Readme database download info, log file path correction fixing issue #85, no "number" in PMDtools

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Below is an example of `config.yaml`, here you will need to download a few datab
     n_tax_reads: 200
 
 
+There are several ways to download the database files. One is to follow this link https://docs.figshare.com/#articles_search and search for the last number in the database links provided above in the "article_id" search bar. This will give you the download url for each file. Then you can either use wget inside a screen session or tmux session to download it, or aria2c, for example, https://aria2.github.io/ .
+
 After you have prepared the sample- and configration-file, please install job-specific environments and update Krona taxonomy:
 
     cd aMeta

--- a/workflow/rules/align.smk
+++ b/workflow/rules/align.smk
@@ -21,7 +21,7 @@ rule Bowtie2_Index:
     log:
         f"{config['bowtie2_patho_db']}_BOWTIE2_BUILD.log",
     shell:
-        "bowtie2-build-l {input.ref} {input.ref} > {log} 2>&1"
+        "bowtie2-build-l --threads {threads} {input.ref} {input.ref} > {log} 2>&1"
 
 
 rule Bowtie2_Pathogenome_Alignment:

--- a/workflow/rules/align.smk
+++ b/workflow/rules/align.smk
@@ -19,7 +19,7 @@ rule Bowtie2_Index:
         *config["envmodules"]["bowtie2"],
     threads: 1
     log:
-        f"logs/BOWTIE2_BUILD/{config['bowtie2_patho_db']}.log",
+        f"{config['bowtie2_patho_db']}_BOWTIE2_BUILD.log",
     shell:
         "bowtie2-build-l {input.ref} {input.ref} > {log} 2>&1"
 

--- a/workflow/rules/align.smk
+++ b/workflow/rules/align.smk
@@ -12,7 +12,7 @@ rule Bowtie2_Index:
             ],
         ),
     input:
-        ref=config["bowtie2_patho_db"],
+        ref=ancient(config["bowtie2_patho_db"]),
     conda:
         "../envs/bowtie2.yaml"
     envmodules:

--- a/workflow/rules/authentic.smk
+++ b/workflow/rules/authentic.smk
@@ -193,7 +193,7 @@ rule PMD_scores:
     envmodules:
         *config["envmodules"]["malt"],
     shell:
-        "(samtools view -h {input.bam} || true) | pmdtools --number 100000 --printDS > {output.scores}"
+        "(samtools view -h {input.bam} || true) | pmdtools --printDS > {output.scores}"
 
 
 rule Authentication_Plots:
@@ -234,7 +234,7 @@ rule Deamination:
     envmodules:
         *config["envmodules"]["malt"],
     shell:
-        "(samtools view {input.bam} || true) | pmdtools --platypus --number 100000 > {output.tmp}; "
+        "(samtools view {input.bam} || true) | pmdtools --platypus > {output.tmp}; "
         "cd results/AUTHENTICATION/{wildcards.sample}/{wildcards.taxid}; "
         "R CMD BATCH $(which plotPMD); "
 

--- a/workflow/rules/authentic.smk
+++ b/workflow/rules/authentic.smk
@@ -122,13 +122,13 @@ rule Samtools_Faidx:
     message:
         "Samtools_Faidx: INDEXING MALT FASTA DATABASE FOR BREADTH_OF_COVERAGE SEQUENCE RETRIEVAL"
     log:
-        "logs/BREADTH_OF_COVERAGE/{prefix}.{fasta}.fai.log",
+        "{prefix}.{fasta}.fai_Samtools_Faidx.log",
     conda:
         "../envs/samtools.yaml"
     envmodules:
         *config["envmodules"]["samtools"],
     shell:
-        "samtools faidx {input.fna}"
+        "samtools faidx {input.fna} 2> {log}"
 
 
 rule Breadth_Of_Coverage:

--- a/workflow/rules/authentic.smk
+++ b/workflow/rules/authentic.smk
@@ -116,7 +116,7 @@ rule Samtools_Faidx:
     output:
         fai="{prefix}.{fasta}.fai",
     input:
-        fna="{prefix}.{fasta}",
+        fna=ancient("{prefix}.{fasta}"),
     wildcard_constraints:
         fasta="(fna|fasta|fa)",
     message:


### PR DESCRIPTION
I tested the version with no "number" parameter of PMDtools and it worked fine.
I corrected the log file path of Bowtie2_Index and Samtools_Faidx which were giving warnings previously in issue #85.
Add some information on ways to download the databases in the README.
Make "ancient" the input file of Bowtie2_Index and Samtools_Faidx because the full database can be downloaded and rerunning the database building and indexing is too much time and memory intensive. 
