### PR TITLE
making aMeta less pathogen oriented

### DIFF
--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -19,9 +19,9 @@ adapters:
 
 # Databases
 krakenuniq_db: resources/KrakenUniq_DB
-bowtie2_patho_db: resources/ref.fa
+bowtie2_db: resources/ref.fa
 pathogenomesFound: resources/pathogenomesFound.tab
-pathogenome_seqid2taxid_db: resources/seqid2taxid.pathogen.map
+bowtie2_seqid2taxid_db: resources/seqid2taxid.pathogen.map
 malt_seqid2taxid_db: resources/KrakenUniq_DB/seqid2taxid.map
 malt_nt_fasta: resources/ref.fa
 malt_accession2taxid: resources/accession2taxid.map

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Here is an example of `samples.tsv`, this implies that the fastq-files are locat
     foo	data/foo.fq.gz
     bar	data/bar.fq.gz
 
+Currently, it is important that the sample names in the first column exactly match the names of the fastq-files in the second column. For example, a fastq-file "data/foo.fq.gz" specified in the "fastq" column, must have a name "foo" in the "sample" column. 
+Please make sure that the names in the first and second columns match.
+
 Below is an example of `config.yaml`, here you will need to download a few databases that we made public (or build databases yourself).
 
     samplesheet: "config/samples.tsv"
@@ -66,13 +69,15 @@ Below is an example of `config.yaml`, here you will need to download a few datab
 
     # Bowtie2 index and helping files for following up microbial pathogens 
     # can be downloaded from https://doi.org/10.17044/scilifelab.21185887
-    bowtie2_patho_db: resources/library.pathogen.fna
+    bowtie2_db: resources/library.pathogen.fna
+    bowtie2_seqid2taxid_db: resources/seqid2taxid.pathogen.map
     pathogenomesFound: resources/pathogensFound.very_inclusive.tab
-    pathogenome_seqid2taxid_db: resources/seqid2taxid.pathogen.map
 
-    # Bowtie2 index for full NCBI NT (for quick followup of prokaryotes and eukaryotes)
-    # can be downloaded from https://doi.org/10.17044/scilifelab.21070063
-    #bowtie2_patho_db: resources/library.fna
+    # Bowtie2 index for full NCBI NT (for quick followup of prokaryotes and eukaryotes),
+    # can be downloaded from https://doi.org/10.17044/scilifelab.21070063 (please unzip files)
+    # For using Bowtie2 NT index, replace "bowtie2_db" and "bowtie2_seqid2taxid_db" above by
+    #bowtie2_db: resources/library.fna
+    #bowtie2_seqid2taxid_db: resources/seqid2taxid.map.orig
 
     # Helping files for building Malt database 
     # can be downloaded from https://doi.org/10.17044/scilifelab.21070063
@@ -231,7 +236,7 @@ example is shown here:
     restart-times: 1
     # Set threads for mapping and fastqc
     set-threads:
-      - Bowtie2_Pathogenome_Alignment=10
+      - Bowtie2_Alignment=10
       - FastQC_BeforeTrimming=5
     # Set resources (runtime in minutes, memory in mb) for malt
     set-resources:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,8 +8,8 @@ samples:
 # Databases
 krakenuniq_db: resources/krakendb
 pathogenomesFound: resources/pathogenomesFound.tab
-pathogenome_seqid2taxid_db: resources/seqid2taxid.pathogen.map
-bowtie2_patho_db: resources/bowtie2db
+bowtie2_seqid2taxid_db: resources/seqid2taxid.pathogen.map
+bowtie2_db: resources/bowtie2db
 malt_seqid2taxid_db: resources/malt_seq2tax
 malt_nt_fasta: resources/maltntfasta
 malt_accession2taxid: resources/malt_acc2tax

--- a/workflow/rules/align.smk
+++ b/workflow/rules/align.smk
@@ -12,7 +12,7 @@ rule Bowtie2_Index:
             ],
         ),
     input:
-        ref=config["bowtie2_db"],
+        ref=ancient(config["bowtie2_db"]),
     conda:
         "../envs/bowtie2.yaml"
     envmodules:

--- a/workflow/rules/align.smk
+++ b/workflow/rules/align.smk
@@ -21,7 +21,7 @@ rule Bowtie2_Index:
     log:
         f"logs/BOWTIE2_BUILD/{config['bowtie2_db']}.log",
     shell:
-        "bowtie2-build-l {input.ref} {input.ref} > {log} 2>&1"
+        "bowtie2-build-l --threads {threads} {input.ref} {input.ref} > {log} 2>&1"
 
 
 rule Bowtie2_Alignment:

--- a/workflow/rules/align.smk
+++ b/workflow/rules/align.smk
@@ -19,7 +19,7 @@ rule Bowtie2_Index:
         *config["envmodules"]["bowtie2"],
     threads: 1
     log:
-        f"logs/BOWTIE2_BUILD/{config['bowtie2_db']}.log",
+        f"{config['bowtie2_db']}_BOWTIE2_BUILD.log",
     shell:
         "bowtie2-build-l --threads {threads} {input.ref} {input.ref} > {log} 2>&1"
 

--- a/workflow/rules/align.smk
+++ b/workflow/rules/align.smk
@@ -1,7 +1,7 @@
 rule Bowtie2_Index:
     output:
         expand(
-            f"{config['bowtie2_patho_db']}{{ext}}",
+            f"{config['bowtie2_db']}{{ext}}",
             ext=[
                 ".1.bt2l",
                 ".2.bt2l",
@@ -12,27 +12,27 @@ rule Bowtie2_Index:
             ],
         ),
     input:
-        ref=ancient(config["bowtie2_patho_db"]),
+        ref=config["bowtie2_db"],
     conda:
         "../envs/bowtie2.yaml"
     envmodules:
         *config["envmodules"]["bowtie2"],
     threads: 1
     log:
-        f"{config['bowtie2_patho_db']}_BOWTIE2_BUILD.log",
+        f"logs/BOWTIE2_BUILD/{config['bowtie2_db']}.log",
     shell:
-        "bowtie2-build-l --threads {threads} {input.ref} {input.ref} > {log} 2>&1"
+        "bowtie2-build-l {input.ref} {input.ref} > {log} 2>&1"
 
 
-rule Bowtie2_Pathogenome_Alignment:
+rule Bowtie2_Alignment:
     output:
-        bam="results/BOWTIE2/{sample}/AlignedToPathogenome.bam",
-        bai="results/BOWTIE2/{sample}/AlignedToPathogenome.bam.bai",
+        bam="results/BOWTIE2/{sample}/AlignedToBowtie2DB.bam",
+        bai="results/BOWTIE2/{sample}/AlignedToBowtie2DB.bam.bai",
     input:
         fastq="results/CUTADAPT_ADAPTER_TRIMMING/{sample}.trimmed.fastq.gz",
         db=rules.Bowtie2_Index.output,
     params:
-        PATHO_DB=lambda wildcards, input: config["bowtie2_patho_db"],
+        BOWTIE2_DB=lambda wildcards, input: config["bowtie2_db"],
     threads: 10
     log:
         "logs/BOWTIE2/{sample}.log",
@@ -43,7 +43,15 @@ rule Bowtie2_Pathogenome_Alignment:
     benchmark:
         "benchmarks/BOWTIE2/{sample}.benchmark.txt"
     message:
-        "Bowtie2_Pathogenome_Alignment: ALIGNING SAMPLE {input.fastq} TO PATHOGENOME WITH BOWTIE2"
+        "Bowtie2_Alignment: ALIGNING SAMPLE {input.fastq} WITH BOWTIE2"
     shell:
-        """bowtie2 --large-index -x {params.PATHO_DB} --end-to-end --threads {threads} --very-sensitive -U {input.fastq} 2> {log} | samtools view -bS -q 1 -h -@ {threads} - | samtools sort - -@ {threads} -o {output.bam} >> {log};"""
-        """samtools index {output.bam}"""
+        """bowtie2 --large-index -x {params.BOWTIE2_DB} --end-to-end --threads {threads} --very-sensitive -U {input.fastq} > $(dirname {output.bam})/AlignedToBowtie2DB.sam 2> {log};"""
+        """grep @ $(dirname {output.bam})/AlignedToBowtie2DB.sam | awk '!seen[$2]++' > $(dirname {output.bam})/header_nodups.txt;"""
+        """grep -v '^@' $(dirname {output.bam})/AlignedToBowtie2DB.sam > $(dirname {output.bam})/AlignedToBowtie2DB.noheader.sam;"""
+        """cat $(dirname {output.bam})/header_nodups.txt $(dirname {output.bam})/AlignedToBowtie2DB.noheader.sam > $(dirname {output.bam})/AlignedToBowtie2DB.nodups.sam;"""
+        """samtools view -bS -q 1 -h -@ {threads} $(dirname {output.bam})/AlignedToBowtie2DB.nodups.sam | samtools sort - -@ {threads} -o {output.bam};"""
+        """samtools index {output.bam};"""
+        """rm $(dirname {output.bam})/header_nodups.txt;"""
+        """rm $(dirname {output.bam})/AlignedToBowtie2DB.noheader.sam;"""
+        """rm $(dirname {output.bam})/AlignedToBowtie2DB.nodups.sam;"""
+        """rm $(dirname {output.bam})/AlignedToBowtie2DB.sam;"""

--- a/workflow/rules/authentic.smk
+++ b/workflow/rules/authentic.smk
@@ -2,13 +2,13 @@ checkpoint Create_Sample_TaxID_Directories:
     """Create taxid directory
 
     For a sample, create taxid for each entry in krakenuniq output
-    taxID.pathogens. Downstream rules use the taxid directories as
+    taxID.species. Downstream rules use the taxid directories as
     input, but it is not known beforehand which these are; they are
     determined by the finds in krakenuniq.
 
     """
     input:
-        pathogens="results/KRAKENUNIQ/{sample}/taxID.pathogens",
+        species="results/KRAKENUNIQ/{sample}/taxID.species",
     output:
         done="results/AUTHENTICATION/{sample}/.extract_taxids_done",
     log:
@@ -17,7 +17,7 @@ checkpoint Create_Sample_TaxID_Directories:
         dir=lambda wildcards: f"results/AUTHENTICATION/{wildcards.sample}",
     shell:
         "mkdir -p {params.dir}; "
-        "while read taxid; do mkdir -p {params.dir}/$taxid; touch {params.dir}/$taxid/.done; done<{input.pathogens};"
+        "while read taxid; do mkdir -p {params.dir}/$taxid; touch {params.dir}/$taxid/.done; done<{input.species};"
         "touch {output.done}"
 
 

--- a/workflow/rules/damage.smk
+++ b/workflow/rules/damage.smk
@@ -2,12 +2,12 @@ rule MapDamage:
     output:
         dir=directory("results/MAPDAMAGE/{sample}"),
     input:
-        pathogen_tax_id="results/KRAKENUNIQ/{sample}/taxID.pathogens",
-        bam="results/BOWTIE2/{sample}/AlignedToPathogenome.bam",
-        bai="results/BOWTIE2/{sample}/AlignedToPathogenome.bam.bai",
+        species_tax_id="results/KRAKENUNIQ/{sample}/taxID.species",
+        bam="results/BOWTIE2/{sample}/AlignedToBowtie2DB.bam",
+        bai="results/BOWTIE2/{sample}/AlignedToBowtie2DB.bam.bai",
     params:
-        pathogenome_path=os.path.dirname(config["pathogenomesFound"]),
-        PATHO_DB=config["bowtie2_patho_db"],
+        bowtie2_seqid2taxid=config["bowtie2_seqid2taxid_db"],
+        BOWTIE2_DB=config["bowtie2_db"],
         options=config["options"].get("MapDamage", ""),
     threads: 10
     log:
@@ -19,13 +19,13 @@ rule MapDamage:
     benchmark:
         "benchmarks/MAPDAMAGE/{sample}.benchmark.txt"
     message:
-        "MapDamage: RUNNING MAPDAMAGE ON PATHOGENS IDENTIFIED IN SAMPLE {input.bam}"
+        "MapDamage: RUNNING MAPDAMAGE ON SPECIES IDENTIFIED BY KRAKENUNIQ IN SAMPLE {input.bam}"
     shell:
         "mkdir {output.dir}; "
-        "if [ -s {input.pathogen_tax_id} ]; then "
-        'cat {input.pathogen_tax_id} | parallel -j {threads} "grep -w {{}} {params.pathogenome_path}/seqid2taxid.pathogen.map | cut -f1 > {output.dir}/{{}}.seq_ids" ; '
-        "for i in $(cat {input.pathogen_tax_id}); do xargs --arg-file={output.dir}/${{i}}.seq_ids samtools view -bh {input.bam} --write-index -@ {threads} -o {output.dir}/${{i}}.tax.bam; done >> {log} 2>&1; "
-        "find {output.dir} -name '*.tax.bam' | parallel -j {threads} \"mapDamage {params.options} -i {{}} -r {params.PATHO_DB} --merge-reference-sequences -d {output.dir}/mapDamage_{{}}\" >> {log} 2>&1 || true; "
+        "if [ -s {input.species_tax_id} ]; then "
+        'cat {input.species_tax_id} | parallel -j {threads} "grep -w {{}} {params.bowtie2_seqid2taxid} | cut -f1 > {output.dir}/{{}}.seq_ids" ; '
+        "for i in $(cat {input.species_tax_id}); do xargs --arg-file={output.dir}/${{i}}.seq_ids samtools view -bh {input.bam} --write-index -@ {threads} -o {output.dir}/${{i}}.tax.bam; done >> {log} 2>&1; "
+        "find {output.dir} -name '*.tax.bam' | parallel -j {threads} \"mapDamage {params.options} -i {{}} -r {params.BOWTIE2_DB} --merge-reference-sequences -d {output.dir}/mapDamage_{{}}\" >> {log} 2>&1 || true; "
         "for filename in {output.dir}/*.tax.bam; do newname=`echo $filename | sed 's/tax\.//g'`; mv $filename $newname; done >> {log} 2>&1; "
         "mv {output.dir}/mapDamage_{output.dir}/* {output.dir} >> {log} 2>&1; "
         "rm -r {output.dir}/mapDamage_results >> {log} 2>&1; "

--- a/workflow/rules/krakenuniq.smk
+++ b/workflow/rules/krakenuniq.smk
@@ -27,6 +27,7 @@ rule Filter_KrakenUniq_Output:
         filtered="results/KRAKENUNIQ/{sample}/krakenuniq.output.filtered",
         pathogens="results/KRAKENUNIQ/{sample}/krakenuniq.output.pathogens",
         pathogen_tax_id="results/KRAKENUNIQ/{sample}/taxID.pathogens",
+        species_tax_id="results/KRAKENUNIQ/{sample}/taxID.species",
     input:
         krakenuniq="results/KRAKENUNIQ/{sample}/krakenuniq.output",
         pathogenomesFound=config["pathogenomesFound"],
@@ -46,7 +47,8 @@ rule Filter_KrakenUniq_Output:
         "Filter_KrakenUniq_Output: APPLYING DEPTH AND BREADTH OF COVERAGE FILTERS TO KRAKENUNIQ OUTPUT FOR SAMPLE {input}"
     shell:
         """{params.exe} {input.krakenuniq} {params.n_unique_kmers} {params.n_tax_reads} {input.pathogenomesFound} &> {log}; """
-        """cut -f7 {output.pathogens} | tail -n +2 > {output.pathogen_tax_id}"""
+        """cut -f7 {output.pathogens} | tail -n +2 > {output.pathogen_tax_id};"""
+        """cut -f7 {output.filtered} | tail -n +2 > {output.species_tax_id}"""
 
 
 rule KrakenUniq2Krona:

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -47,14 +47,14 @@ properties:
     type: string
     description: >-
       KrakenUniq database
-  bowtie2_patho_db:
+  bowtie2_db:
     type: string
     description: >-
-      Bowtie2 pathogenome database
-  pathogenome_seqid2taxid_db:
+      Bowtie2 database (can be PathoGenome or full NT)
+  bowtie2_seqid2taxid_db:
     type: string
     description: >-
-      A mapping file for finding correspondence between reference sequence ids from fasta and taxIDs from taxonomy for pathogens only
+      A mapping file for finding correspondence between reference sequence ids from fasta and taxIDs from taxonomy
   pathogenomesFound:
     type: string
     description: >-
@@ -115,7 +115,7 @@ properties:
       bowtie2:
         default: []
         description: >-
-          Note that rule Bowtie2_Pathogenome_Alignment also requires
+          Note that rule Bowtie2_Alignment also requires
           samtools.
         $ref: "#/definitions/envmodules_list"
         example:
@@ -236,9 +236,9 @@ properties:
 required:
   - samplesheet
   - krakenuniq_db
-  - bowtie2_patho_db
+  - bowtie2_db
   - pathogenomesFound
-  - pathogenome_seqid2taxid_db
+  - bowtie2_seqid2taxid_db
   - malt_seqid2taxid_db
   - malt_nt_fasta
   - malt_accession2taxid


### PR DESCRIPTION
I made a number of changes, trying to make aMeta follow up all detected by KrakenUniq species instead of pathogens only. Previously it was too pathogen oriented, now we deliver all followup stats for all detected microbes (including pathogens, if present, of course). This commit should fix a few issues such as https://github.com/NBISweden/aMeta/issues/122, https://github.com/NBISweden/aMeta/issues/120, https://github.com/NBISweden/aMeta/issues/119, https://github.com/NBISweden/aMeta/issues/84